### PR TITLE
Fix less @import compilation step

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ module.exports = {
         return transformJs(src)
       case '.css':
       case '.less':
-        return transformCss(src)
+        return transformCss(src, filename)
       default:
         return src
     }
@@ -26,9 +26,9 @@ function transformJs (src) {
   }).code
 }
 
-function transformCss (src) {
+function transformCss (src, filename) {
   let code
-  less.render(src, { sync: true }, (_, result) => {
+  less.render(src, { filename }, (_, result) => {
     code = result.css
   })
   code = `module.exports = require('@qubit/add-stylesheet')(


### PR DESCRIPTION
When running `npx jest --no-cache` in a experience related repo such as `@qubit/search-preview` throws an `TypeError: Cannot read property 'css' of undefined` error. Error is due to the ability of `less.render` to follow `@import` rules. By providing the filename less is able to resolve the relative location of the imported file and correctly append it to the rendered css. Also, there is no need to provide `sync: true` as less runs synchronously when a callback is provided.