### PR TITLE
Fix jest local module resolution bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6,7 +6,7 @@
   "packages": {
     "": {
       "name": "@qubit/jest",
-      "version": "1.3.0",
+      "version": "1.4.0",
       "license": "ISC",
       "dependencies": {
         "@qubit/add-stylesheet": "^1.2.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "jest": {
     "transform": {
-      ".*(.js|.css|.less)$": "@qubit/jest"
+      ".*(.js|.css|.less)$": "./index.js"
     },
     "transformIgnorePatterns": []
   },


### PR DESCRIPTION
Jest is unable to resolve any modules not present in the node_modules folder when it parses its config. To use the @qubit/jest package it must either be added as a circular dependency or referenced by relative path for it to resolve. Without this the jest fail to run